### PR TITLE
devOps_integracao

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         volumes:
           - '.:/app'
           - '/app/node_modules'
+        networks:
+          - network-api
         ports:
           - '3000:3000'
         environment:
@@ -15,5 +17,8 @@ services:
         tty: true
         stdin_open: true
       
-      
+networks:
+  network-api:
+    external:
+      name: network-api
       


### PR DESCRIPTION
### Issues relacionadas:
- #56
### Por que esse PR é necessário ?
Integração dos containers do back e do front.

### Tarefas

- [ ] Inserir networking no docker-compose.yml, para comunicação do front e back.

### Descrição:
Esse PR, tem o intuito de realizar a integração do front com o back do projeto. Permitindo a comunicação entre ambos

### Critérios de aceitação.
A pessoa responsável pela review deverá rodar na sua máquina as alterações feitas e comprovar que está tudo funcionando corretamente.  
